### PR TITLE
[BUGFIX] Quote PHP version numbers in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
   composer-validate:
     name: "Composer validate"
     runs-on: ubuntu-22.04
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-22.04
@@ -79,4 +79,4 @@ jobs:
           - "composer:normalize"
           - "yaml:lint"
         php-version:
-          - 8.2
+          - '8.2'


### PR DESCRIPTION
This keeps `8.0` from getting rounded to `8`.