### PR TITLE
[FEATURE] Use `typo3/cms-composer-installers` V4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"typo3/cms-adminpanel": "^11.5",
 		"typo3/cms-belog": "^11.5",
 		"typo3/cms-beuser": "^11.5",
+		"typo3/cms-composer-installers": "^4.0.0-rc1",
 		"typo3/cms-core": "^11.5.10",
 		"typo3/cms-felogin": "^11.5",
 		"typo3/cms-fluid-styled-content": "^11.5",


### PR DESCRIPTION
This keeps most non-public files out of the document root.