### PR TITLE
[TASK] Upgrade DDEV to PHP 8.1

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: typo3-testing-11-5
 type: typo3
 docroot: public
-php_version: "7.4"
+php_version: "8.1"
 webserver_type: apache-fpm
 router_http_port: "8080"
 router_https_port: "8081"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,4 @@ jobs:
           - "composer:normalize"
           - "yaml:lint"
         php-version:
-          - '8.2'
+          - '8.1'

--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,6 @@
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},
-		"platform": {
-			"php": "7.4.29"
-		},
 		"preferred-install": {
 			"*": "dist"
 		},


### PR DESCRIPTION
We would like to have the improved performance and security.

Also, this allows us to catch problems with higher PHP versions by manual testing. (Those tend to be more probably than problems with lower versions.)