### PR TITLE
[TASK] Pin seminars to 4.4.0

### DIFF
--- a/.ddev/docker-compose.packages.yaml.template
+++ b/.ddev/docker-compose.packages.yaml.template
@@ -1,8 +1,0 @@
-# This is a template file for mounting your local extensions into this distribution.
-# Copy this file to docker-compose.packages.yaml and modify it to your needs. (More details in the README.)
-version: "3.6"
-
-services:
-  web:
-    volumes:
-      - "$HOME/src/typo3/ext/seminars:/var/www/html/packages/seminars:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"oliverklee/feuserextrafields": "^3.2.1",
 		"oliverklee/oelib": "^4.3.1",
 		"oliverklee/onetimeaccount": "^5.1.0",
-		"oliverklee/seminars": "dev-main",
+		"oliverklee/seminars": "^4.4.0",
 		"oliverklee/typo3-devsite": "^4.0.0",
 		"ttn/tea": "^1.1.0",
 		"typo3/cms-about": "^9.5",


### PR DESCRIPTION
This is the last version supporting TYPO3 9LTS.