### PR TITLE
[TASK] Keep MySQL/MariaDB in strict mode

### DIFF
--- a/.ddev/mysql/sql_mode.cnf
+++ b/.ddev/mysql/sql_mode.cnf
@@ -1,4 +1,0 @@
-[mysqld]
-# This is required for the seminars FE editor to graciously convert "" to 0 for integer columns
-# (which is a shortcoming of the "mkforms" extension).
-sql_mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION


### PR DESCRIPTION
Having it not-as-strict was only necessary for mkforms (which the seminars extension now is not be using anymore).