### PR TITLE
[TASK] Remove `georgringer/autoswitchtolistview`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
 	},
 	"require": {
 		"php": ">= 7.4.29",
-		"georgringer/autoswitchtolistview": "^2.0.4",
 		"helhum/typo3-console": "^7.1.4",
 		"oliverklee/feuserextrafields": "dev-main",
 		"oliverklee/oelib": "dev-main",


### PR DESCRIPTION
With this extension installed, we cannot translate folders anymore.