### PR TITLE
[CLEANUP] Streamling the `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,6 @@
 /public/*
 !/public/.htaccess
 !/public/favicon.ico
-!/public/typo3conf
-/public/typo3conf/*
-!/public/typo3conf/AdditionalConfiguration.php
-!/public/typo3conf/LocalConfiguration.php
-/src/extensions/*
-!/src/extensions/site-dev
 /var/*
 !/var/labels
 /vendor


### PR DESCRIPTION
With TYPO3 12LTS, there are no extensions or configuration files left in `typo3conf/ or `public/`. So we can simplify or remove the `.gitignore` entries for those directories.