### PR TITLE
[TASK] Pin oelib to 5.5.2

### DIFF
--- a/.ddev/docker-compose.packages.yaml.template
+++ b/.ddev/docker-compose.packages.yaml.template
@@ -5,7 +5,6 @@ version: "3.6"
 services:
   web:
     volumes:
-      - "$HOME/src/typo3/ext/oelib:/var/www/html/packages/oelib:cached,ro"
       - "$HOME/src/typo3/ext/onetimeaccount:/var/www/html/packages/onetimeaccount:cached,ro"
       - "$HOME/src/typo3/ext/seminars:/var/www/html/packages/seminars:cached,ro"
       - "$HOME/src/typo3/ext/typo3-devsite:/var/www/html/packages/typo3-devsite:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"georgringer/autoswitchtolistview": "^2.0.4",
 		"helhum/typo3-console": "^6.7.6",
 		"oliverklee/feuserextrafields": "^5.4.0",
-		"oliverklee/oelib": "dev-main",
+		"oliverklee/oelib": "^5.2.2",
 		"oliverklee/onetimeaccount": "dev-main",
 		"oliverklee/seminars": "dev-main",
 		"oliverklee/typo3-devsite": "dev-main",


### PR DESCRIPTION
This is the last version to support TYPO3 10LTS.