### PR TITLE
[TASK] Pin onetimeaccount to 6.4.0

### DIFF
--- a/.ddev/docker-compose.packages.yaml.template
+++ b/.ddev/docker-compose.packages.yaml.template
@@ -3,6 +3,5 @@
 services:
   web:
     volumes:
-      - "$HOME/src/typo3/ext/onetimeaccount:/var/www/html/packages/onetimeaccount:cached,ro"
       - "$HOME/src/typo3/ext/seminars:/var/www/html/packages/seminars:cached,ro"
       - "$HOME/src/typo3/ext/typo3-devsite:/var/www/html/packages/typo3-devsite:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"helhum/typo3-console": "^6.7.6",
 		"oliverklee/feuserextrafields": "^5.4.0",
 		"oliverklee/oelib": "^5.2.2",
-		"oliverklee/onetimeaccount": "dev-main",
+		"oliverklee/onetimeaccount": "^6.4.0",
 		"oliverklee/seminars": "dev-main",
 		"oliverklee/typo3-devsite": "dev-main",
 		"ttn/tea": "^2.0.1",


### PR DESCRIPTION
Onetimeaccount will drop support for TYPO3 10LTS in a minute.