### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2.6
       - name: "Show Composer version"
@@ -38,6 +39,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2.6
       - name: "Validate the composer.json"
@@ -60,6 +62,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2.6
       - name: "Show Composer version"
@@ -111,6 +114,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
           tools: composer:v2
 
@@ -151,6 +155,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2.6
       - name: "Show Composer version"
@@ -191,6 +196,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2.6
       - name: "Show Composer version"


### PR DESCRIPTION
This will allow us to see (and error out on) all warnings and notices.

Fixes #259