### PR TITLE
[TASK] Limit Dependabot to Symfony < 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "development"
+    ignore:
+      - dependency-name: "symfony/*"
+        versions: [ ">= 7.0.0" ]
     versioning-strategy: "increase"


### PR DESCRIPTION
As we still support PHP 8.1, we cannot allow Symfony 7.