### PR TITLE
[BUGFIX] Stop logging debug messages

### DIFF
--- a/config/system/settings.php
+++ b/config/system/settings.php
@@ -103,12 +103,6 @@ return [
     ],
     'LOG' => [
         'writerConfiguration' => [
-            LogLevel::DEBUG => [
-                FileWriter::class => [
-                    'disabled' => false,
-                    'logFileInfix' => 'debug',
-                ],
-            ],
             LogLevel::INFO => [
                 FileWriter::class => [
                     'disabled' => false,


### PR DESCRIPTION
This is broken somehow and causes a crash after sending an email.