### PR TITLE
[TASK] Rename the `ci:*` Composer scripts to `check:*`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Show the Composer configuration
         run: composer config --global --list
       - name: Run PHP lint
-        run: "composer ci:php:lint"
+        run: "composer check:php:lint"
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
       - name: Install Composer dependencies
         run: "composer update --no-progress"
       - name: Run command
-        run: "composer ci:${{ matrix.command }}"
+        run: "composer check:${{ matrix.command }}"
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
       - name: Install Composer dependencies
         run: "composer update --no-progress"
       - name: Run the tests
-        run: "composer ci:tests:unit"
+        run: "composer check:tests:unit"
 
   functional-tests:
     name: Functional Tests
@@ -228,4 +228,4 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:tests:functional
+          composer check:tests:functional

--- a/composer.json
+++ b/composer.json
@@ -97,30 +97,27 @@
 		"post-autoload-dump": [
 			"@typo3-cms-scripts"
 		],
-		"ci": [
-			"@ci:static"
-		],
-		"ci:composer:normalize": [
+		"check:composer:normalize": [
 			"@composer normalize --dry-run --no-check-lock",
 			"@composer normalize --dry-run --no-check-lock src/extensions/site-dev/composer.json"
 		],
-		"ci:json:lint": "find . -path '*/public/*' ! -path '*/var/*' ! -path '*/vendor/*' -name '*.json' | xargs -r php vendor/bin/jsonlint -q",
-		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --using-cache no --diff",
-		"ci:php:lint": "find *.php .*.php config src/extensions/site-dev -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-		"ci:php:stan": "phpstan --no-progress",
-		"ci:static": [
-			"@ci:composer:normalize",
-			"@ci:json:lint",
-			"@ci:php:lint",
-			"@ci:php:stan",
-			"@ci:php:cs-fixer",
-			"@ci:typoscript:lint",
-			"@ci:yaml:lint"
+		"check:json:lint": "find . -path '*/public/*' ! -path '*/var/*' ! -path '*/vendor/*' -name '*.json' | xargs -r php vendor/bin/jsonlint -q",
+		"check:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --using-cache no --diff",
+		"check:php:lint": "find *.php .*.php config src/extensions/site-dev -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+		"check:php:stan": "phpstan --no-progress",
+		"check:static": [
+			"@check:composer:normalize",
+			"@check:json:lint",
+			"@check:php:lint",
+			"@check:php:stan",
+			"@check:php:cs-fixer",
+			"@check:typoscript:lint",
+			"@check:yaml:lint"
 		],
-		"ci:tests:functional": "phpunit -c config/FunctionalTests.xml",
-		"ci:tests:unit": "phpunit -c config/UnitTests.xml",
-		"ci:typoscript:lint": "typoscript-lint -c config/TypoScriptLint.yaml --ansi -n --fail-on-warnings -vvv src/extensions/site-dev/Configuration/TsConfig src/extensions/site-dev/Configuration/TypoScript",
-		"ci:yaml:lint": "find .ddev .github config src/extensions/site-dev -name '*.yml' -o -name '*.yaml' | xargs php ./vendor/bin/yaml-lint",
+		"check:tests:functional": "phpunit -c config/FunctionalTests.xml",
+		"check:tests:unit": "phpunit -c config/UnitTests.xml",
+		"check:typoscript:lint": "typoscript-lint -c config/TypoScriptLint.yaml --ansi -n --fail-on-warnings -vvv src/extensions/site-dev/Configuration/TsConfig src/extensions/site-dev/Configuration/TypoScript",
+		"check:yaml:lint": "find .ddev .github config src/extensions/site-dev -name '*.yml' -o -name '*.yaml' | xargs php ./vendor/bin/yaml-lint",
 		"fix": [
 			"@fix:composer",
 			"@fix:php:cs"
@@ -136,17 +133,16 @@
 		]
 	},
 	"scripts-descriptions": {
-		"ci": "Runs all code checks.",
-		"ci:composer:normalize": "Checks the formatting and structure of the composer.json.",
-		"ci:json:lint": "Lints the JSON files.",
-		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
-		"ci:php:lint": "Lints the PHP files for syntax errors.",
-		"ci:php:stan": "Checks the PHP types using PHPStan.",
-		"ci:static": "Runs all static code checks (syntax, style, types).",
-		"ci:tests:functional": "Runs the functional tests.",
-		"ci:tests:unit": "Runs the unit tests.",
-		"ci:typoscript:lint": "Lints the TypoScript files.",
-		"ci:yaml:lint": "Lints the YAML files for syntax errors.",
+		"check:composer:normalize": "Checks the formatting and structure of the composer.json.",
+		"check:json:lint": "Lints the JSON files.",
+		"check:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
+		"check:php:lint": "Lints the PHP files for syntax errors.",
+		"check:php:stan": "Checks the PHP types using PHPStan.",
+		"check:static": "Runs all static code checks (syntax, style, types).",
+		"check:tests:functional": "Runs the functional tests.",
+		"check:tests:unit": "Runs the unit tests.",
+		"check:typoscript:lint": "Lints the TypoScript files.",
+		"check:yaml:lint": "Lints the YAML files for syntax errors.",
 		"fix": "Reformats the code.",
 		"fix:composer": "Reformats and sorts the composer.json files.",
 		"fix:php:cs": "Fixes the code style with PHP-CS-Fixer.",


### PR DESCRIPTION
These scripts are not specific to the CI pipeline, and their names should reflect that.