### PR TITLE
[TASK] Add DB credentials for the functionals to the DDEV config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,7 +15,11 @@ database:
 use_dns_when_possible: true
 timezone: Europe/Berlin
 composer_version: "2"
-web_environment: []
+web_environment:
+    - typo3DatabaseHost=db
+    - typo3DatabasePassword=db
+    - typo3DatabaseUsername=db
+    - typo3DatabaseName=test
 corepack_enable: false
 
 # Key features of DDEV's config.yaml:
@@ -31,7 +35,7 @@ corepack_enable: false
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
+# php_version: "8.3"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to DDEV's' behavior,
@@ -46,7 +50,7 @@ corepack_enable: false
 #   version: <version> # database version, like "10.11" or "8.0"
 #   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
 #   MySQL versions can be 5.5-8.0, 8.4
-#   PostgreSQL versions can be 9-17
+#   PostgreSQL versions can be 9-18
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
 # router_https_port: <port> # Port for https (defaults to global configuration, usually 443)


### PR DESCRIPTION
This allows running the functional tests from the command line without having to provide the DDEV DB credentials as environment variables.