### PR TITLE
[BUGFIX] Work around bug with symfony/dependency-injection 7.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
 		"typo3/coding-standards": "0.8.0",
 		"typo3/testing-framework": "^9.3.0"
 	},
+	"conflict": {
+		"symfony/dependency-injection": "7.4.0"
+	},
 	"repositories": [
 		{
 			"type": "path",


### PR DESCRIPTION
symfony/dependency-injection 7.4.0 introduced a
backwards-imcompatible change that triggered PHP errors with the current versions of TYPO3 12LTS and 13LTS.

Until the bug is fixed in symfony/dependency-injection or until the workarounds in the TYPO3 Core are released, we need to avoid installing symfony/dependency-injection 7.4.0.

https://github.com/symfony/symfony/pull/62544
https://forge.typo3.org/issues/108349