### PR TITLE
[BUGFIX] Work around bug with symfony/dependency-injection 7.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
 		"typo3/testing-framework": "^8.2.3"
 	},
 	"conflict": {
-		"phpstan/phpdoc-parser": "< 1.0 || >= 2.0"
+		"phpstan/phpdoc-parser": "< 1.0 || >= 2.0",
+		"symfony/dependency-injection": "7.4.0"
 	},
 	"repositories": [
 		{


### PR DESCRIPTION
symfony/dependency-injection 7.4.0 introduced a
backwards-imcompatible change that triggered PHP errors with the current versions of TYPO3 12LTS and 13LTS.

Until the bug is fixed in symfony/dependency-injection or until the workarounds in the TYPO3 Core are released, we need to avoid installing symfony/dependency-injection 7.4.0.

https://github.com/symfony/symfony/pull/62544
https://forge.typo3.org/issues/108349