### PR TITLE
[BUGFIX] Avoid georgringer/autoswitchtolistview 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "development"
+    ignore:
+      - dependency-name: "georgringer/autoswitchtolistview"
+        versions: [ "3.1.0" ]
     versioning-strategy: "increase"
     commit-message:
       prefix: "[Dependabot] "

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
 		"typo3/coding-standards": "0.8.0",
 		"typo3/testing-framework": "^9.3.0"
 	},
+	"conflict": {
+		"georgringer/autoswitchtolistview": "3.1.0"
+	},
 	"repositories": [
 		{
 			"type": "path",


### PR DESCRIPTION
This version crashes with PHP versions lower than 8.4.

https://github.com/georgringer/autoswitchtolistview/pull/21 https://wiki.php.net/rfc/new_without_parentheses