### PR TITLE
[BUGFIX] Avoid georgringer/autoswitchtolistview 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
 		"typo3/testing-framework": "^8.2.3"
 	},
 	"conflict": {
+		"georgringer/autoswitchtolistview": "3.1.0",
 		"phpstan/phpdoc-parser": "< 1.0 || >= 2.0"
 	},
 	"repositories": [


### PR DESCRIPTION
This version crashes with PHP versions lower than 8.4.

https://github.com/georgringer/autoswitchtolistview/pull/21 https://wiki.php.net/rfc/new_without_parentheses