### PR TITLE
[TASK] Adapt links to the moved repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This is a TYPO3 distribution which I use to manually test my extensions:
 
-- [feuserextrafields](https://github.com/oliverklee/ext-feuserextrafields)
+- [feuserextrafields](https://github.com/oliverklee-de/feuserextrafields)
   (once it supports TYPO3 13LTS)
-- [oelib](https://github.com/oliverklee/ext-oelib)
+- [oelib](https://github.com/oliverklee-de/oelib)
   (once it supports TYPO3 13LTS)
-- [onetimeaccount](https://github.com/oliverklee/ext-onetimeaccount)
+- [onetimeaccount](https://github.com/oliverklee-de/onetimeaccount)
   (once it supports TYPO3 13LTS)
-- [seminars](https://github.com/oliverklee/ext-seminars)
-  (once it [supports TYPO3 13LTS](https://github.com/oliverklee/ext-seminars/wiki/Early-access-program-for-newer-TYPO3-versions))
+- [seminars](https://github.com/oliverklee-de/seminars)
+  (once it [supports TYPO3 13LTS](https://github.com/oliverklee-de/seminars/wiki/Early-access-program-for-newer-TYPO3-versions))
 - [tea](https://github.com/TYPO3BestPractices/tea)
   (once it supports TYPO3 13LTS)
 

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 		}
 	],
 	"support": {
-		"issues": "https://github.com/oliverklee/TYPO3-testing-distribution/issues",
-		"source": "https://github.com/oliverklee/TYPO3-testing-distribution"
+		"issues": "https://github.com/oliverklee-de/TYPO3-testing-distribution/issues",
+		"source": "https://github.com/oliverklee-de/TYPO3-testing-distribution"
 	},
 	"require": {
 		"php": "^8.2",


### PR DESCRIPTION
This repository was moved to a GitHub organization.
 Hence we need to adapt all corresponding links.