### PR TITLE
[TASK] Adapt links to the moved repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This is a TYPO3 distribution which I use to manually test my extensions:
 
-- [feuserextrafields](https://github.com/oliverklee/ext-feuserextrafields)
-- [oelib](https://github.com/oliverklee/ext-oelib)
-- [onetimeaccount](https://github.com/oliverklee/ext-onetimeaccount)
-- [seminars](https://github.com/oliverklee/ext-seminars)
+- [feuserextrafields](https://github.com/oliverklee-de/feuserextrafields)
+- [oelib](https://github.com/oliverklee-de/oelib)
+- [onetimeaccount](https://github.com/oliverklee-de/onetimeaccount)
+- [seminars](https://github.com/oliverklee-de/seminars)
 - [tea](https://github.com/TYPO3BestPractices/tea)
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 		}
 	],
 	"support": {
-		"issues": "https://github.com/oliverklee/TYPO3-testing-distribution/issues",
-		"source": "https://github.com/oliverklee/TYPO3-testing-distribution"
+		"issues": "https://github.com/oliverklee-de/TYPO3-testing-distribution/issues",
+		"source": "https://github.com/oliverklee-de/TYPO3-testing-distribution"
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",


### PR DESCRIPTION
This repository was moved to a GitHub organization. Hence we need to adapt all corresponding links.