### PR TITLE
[TASK] Update and pin the development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,14 +53,14 @@
 		"phpstan/phpstan": "2.1.38",
 		"phpstan/phpstan-phpunit": "2.0.14",
 		"phpstan/phpstan-strict-rules": "2.0.8",
-		"phpunit/phpunit": "^11.5.50",
+		"phpunit/phpunit": "11.5.52",
 		"saschaegerer/phpstan-typo3": "2.1.1",
 		"seld/jsonlint": "1.11.0",
 		"ssch/typo3-rector": "3.11.0",
 		"ssch/typo3-rector-testing-framework": "3.0.0",
-		"symfony/yaml": "7.3.5",
+		"symfony/yaml": "7.4.1",
 		"typo3/coding-standards": "0.8.0",
-		"typo3/testing-framework": "^9.3.0"
+		"typo3/testing-framework": "9.3.0"
 	},
 	"conflict": {
 		"georgringer/autoswitchtolistview": "3.1.0"


### PR DESCRIPTION
This helps avoid random CI failures when a new version of a development dependency gets released.