### PR TITLE
[TASK] Use the default router ports for DDEV

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,6 @@ type: typo3
 docroot: public
 php_version: "8.1"
 webserver_type: apache-fpm
-router_http_port: "8080"
-router_https_port: "8081"
 xdebug_enabled: false
 additional_hostnames:
     - typo3-testing-11-5-en

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To test a local development copies of extension in this distribution:
     - `ddev launch typo3`
 - Frontend (DE):
     - `ddev launch`
-- Frontend (EN): https://typo3-testing-10-4-en.ddev.site:8081/
+- Frontend (EN): https://typo3-testing-10-4-en.ddev.site
 - MailHog:
     - `ddev launch -m`
 

--- a/config/sites/main/config.yaml
+++ b/config/sites/main/config.yaml
@@ -1,10 +1,10 @@
-base: 'https://typo3-testing-11-5.ddev.site:8081/'
+base: 'https://typo3-testing-11-5.ddev.site'
 baseVariants: { }
 errorHandling: { }
 languages:
   - title: Deutsch
     enabled: true
-    base: 'https://typo3-testing-11-5.ddev.site:8081'
+    base: 'https://typo3-testing-11-5.ddev.site'
     typo3Language: de
     locale: de_DE.UTF-8
     iso-639-1: de
@@ -15,7 +15,7 @@ languages:
     languageId: '0'
   - title: Englisch
     enabled: true
-    base: 'https://typo3-testing-11-5-en.ddev.site:8081'
+    base: 'https://typo3-testing-11-5-en.ddev.site'
     typo3Language: default
     locale: en_US.UTF-8
     iso-639-1: en


### PR DESCRIPTION
Now that local webservers on port 80 on development machines are no longer common, there is no need to configure non-default router ports for DDEV.