### PR TITLE
[TASK] Avoid CI with PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
-          - '8.5'
   composer-validate:
     name: Composer validate
     runs-on: ubuntu-24.04
@@ -50,7 +49,7 @@ jobs:
       matrix:
         php-version:
           - '8.2'
-          - '8.5'
+          - '8.4'
   code-quality:
     name: Code quality checks
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Our dependencies are not ready for PHP 8.5 yet.