### PR TITLE
[TASK] Pin `oliverklee/feuserextrafields` to 6.7.1

### DIFF
--- a/.ddev/docker-compose.extensions.yaml.template
+++ b/.ddev/docker-compose.extensions.yaml.template
@@ -4,7 +4,6 @@
 services:
   web:
     volumes:
-      - "$HOME/src/typo3/ext/feuserextrafields:/var/www/html/src/extensions/feuserextrafields:cached,ro"
       - "$HOME/src/typo3/ext/oelib:/var/www/html/src/extensions/oelib:cached,ro"
       - "$HOME/src/typo3/ext/onetimeaccount:/var/www/html/src/extensions/onetimeaccount:cached,ro"
       - "$HOME/src/typo3/ext/seminars:/var/www/html/src/extensions/seminars:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": "^7.4 || ^8.0",
 		"georgringer/autoswitchtolistview": "^2.0.4",
 		"helhum/typo3-console": "^7.1.4",
-		"oliverklee/feuserextrafields": "dev-main",
+		"oliverklee/feuserextrafields": "6.7.1",
 		"oliverklee/oelib": "dev-main",
 		"oliverklee/onetimeaccount": "dev-main",
 		"oliverklee/seminars": "dev-main",


### PR DESCRIPTION
Version 6.7.1 is the last version that still supports TYPO3 11LTS. So we won't be able to use `dev-main` anymore.

Run command:

```
ddev composer req oliverklee/feuserextrafields:6.7.1
```