### PR TITLE
[TASK] Pin oelib to 6.3.1

### DIFF
--- a/.ddev/docker-compose.extensions.yaml.template
+++ b/.ddev/docker-compose.extensions.yaml.template
@@ -4,7 +4,6 @@
 services:
   web:
     volumes:
-      - "$HOME/src/typo3/ext/oelib:/var/www/html/src/extensions/oelib:cached,ro"
       - "$HOME/src/typo3/ext/onetimeaccount:/var/www/html/src/extensions/onetimeaccount:cached,ro"
       - "$HOME/src/typo3/ext/seminars:/var/www/html/src/extensions/seminars:cached,ro"
       - "$HOME/src/typo3/ext/seminars-premium:/var/www/html/src/extensions/seminars-premium:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"georgringer/autoswitchtolistview": "^2.0.4",
 		"helhum/typo3-console": "^7.1.4",
 		"oliverklee/feuserextrafields": "6.7.1",
-		"oliverklee/oelib": "dev-main",
+		"oliverklee/oelib": "6.3.1",
 		"oliverklee/onetimeaccount": "dev-main",
 		"oliverklee/seminars": "dev-main",
 		"oliverklee/site-dev": "@dev",


### PR DESCRIPTION
oelib 6.3.1 is the last version to still support TYPO3 11LTS.