### PR TITLE
[TASK] Pin `ttn/tea` to version 4.1.0

### DIFF
--- a/.ddev/docker-compose.extensions.yaml.template
+++ b/.ddev/docker-compose.extensions.yaml.template
@@ -9,4 +9,3 @@ services:
       - "$HOME/src/typo3/ext/onetimeaccount:/var/www/html/src/extensions/onetimeaccount:cached,ro"
       - "$HOME/src/typo3/ext/seminars:/var/www/html/src/extensions/seminars:cached,ro"
       - "$HOME/src/typo3/ext/seminars-premium:/var/www/html/src/extensions/seminars-premium:cached,ro"
-      - "$HOME/src/typo3/ext/tea:/var/www/html/src/extensions/tea:cached,ro"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"oliverklee/oelib": "dev-main",
 		"oliverklee/onetimeaccount": "dev-main",
 		"oliverklee/site-dev": "@dev",
-		"ttn/tea": "dev-main",
+		"ttn/tea": "4.1.0",
 		"typo3/cms-adminpanel": "^12.4",
 		"typo3/cms-belog": "^12.4",
 		"typo3/cms-beuser": "^12.4",


### PR DESCRIPTION
Tea 4.1.0 is the last version to still support TYPO3 12LTS.

```
composer req ttn/tea:4.1.0
```