### PR TITLE
[TASK] Drop redundant Core extension requirement from tests

### DIFF
--- a/src/extensions/site-dev/Tests/Functional/UniverseTest.php
+++ b/src/extensions/site-dev/Tests/Functional/UniverseTest.php
@@ -12,8 +12,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class UniverseTest extends FunctionalTestCase
 {
-    protected array $coreExtensionsToLoad = ['extbase', 'fluid'];
-
     protected array $testExtensionsToLoad = ['oliverklee/site-dev'];
 
     /**


### PR DESCRIPTION
Extbase and Fluid are already always loaded by default.